### PR TITLE
Cutting columns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ options:
   -p, --png             Write a PNG file instead of plotting results.
   -t TITLE, --title TITLE
                         Title of the chart.
+  -I {True,False}, --ignore-first-column {True,False}
+                        Ignores the first column of the csv data                  
   -l {en,fr}, --lang {en,fr}
                         Change the language. (default: "en")
   -T {int,str}, --type {int,str}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ options:
   -p, --png             Write a PNG file instead of plotting results.
   -t TITLE, --title TITLE
                         Title of the chart.
-  -I {True,False}, --ignore-first-column {True,False}
+  -I , --ignore-first-column
                         Ignores the first column of the csv data                  
   -l {en,fr}, --lang {en,fr}
                         Change the language. (default: "en")

--- a/discord-bot/major_bot.py
+++ b/discord-bot/major_bot.py
@@ -257,7 +257,7 @@ async def major_display(inter, visibility: str = commands.Param(name="visibilit√
 
     csv_file = "major_bot.csv"
     dict_to_csv(RESULTS, csv_file)
-    results = mj.read_and_aggregate_csv(csv_file, category_names=GRADES, values_type='str')
+    results = mj.read_and_aggregate_csv(csv_file, category_names=GRADES, ignore_first_column=False, values_type='str')
     # Remove special chars for Windows files
     png_file = re.sub(r'\W', '_', QUESTION) + '.png'
     mj.survey(results, category_names=GRADES, title=QUESTION, plot=False, display_major=False)

--- a/examples/resto-googleforms.csv
+++ b/examples/resto-googleforms.csv
@@ -1,0 +1,7 @@
+FirstColumn 1,Pataterie,Burger King,3 Brasseurs,Soleil Italien,Régent
+FirstColumn 2,3,1,3,2,1
+FirstColumn 3,3,1,4,3,1
+FirstColumn 4,3,2,5,4,1
+FirstColumn 5,4,2,5,4,2
+FirstColumn 6,4,3,5,4,2
+FirstColumn 7,4,3,5,5,3

--- a/majority_judgment.py
+++ b/majority_judgment.py
@@ -14,8 +14,12 @@ import re
 
 
 # Supported values_type : 'int' or 'str'
-def read_and_aggregate_csv(file_path, category_names, values_type="int"):
+def read_and_aggregate_csv(file_path, category_names, ignore_first_column,values_type="int"):
     df = pd.read_csv(file_path)
+    # Deleting the first column of the csv if -i has been called
+    if ignore_first_column == True:
+        first_column = df.columns[0]
+        df = df.drop([first_column], axis=1)
     max_count = len(category_names)
 
     if values_type == "int":
@@ -223,6 +227,13 @@ Examples of usages:
         action='store_true',
         default=False
     )
+    parser.add_argument(
+        "-I",
+        "--ignore-first-column",
+        help="""Ignores the first column of the csv data.""",
+        action='store_true',
+        default=False
+    )
 
     args = parser.parse_args()
 
@@ -251,5 +262,5 @@ Examples of usages:
     else:
         plot = True
 
-    results = read_and_aggregate_csv(args.csv, category_names, args.type)
+    results = read_and_aggregate_csv(args.csv, category_names, args.ignore_first_column, args.type)
     survey(results, category_names, args.title, not args.disable_major, plot)

--- a/majority_judgment.py
+++ b/majority_judgment.py
@@ -16,7 +16,7 @@ import re
 # Supported values_type : 'int' or 'str'
 def read_and_aggregate_csv(file_path, category_names, ignore_first_column,values_type="int"):
     df = pd.read_csv(file_path)
-    # Deleting the first column of the csv if -i has been called
+    # Deleting the first column of the csv if -I has been called
     if ignore_first_column == True:
         first_column = df.columns[0]
         df = df.drop([first_column], axis=1)

--- a/majority_judgment.py
+++ b/majority_judgment.py
@@ -14,7 +14,7 @@ import re
 
 
 # Supported values_type : 'int' or 'str'
-def read_and_aggregate_csv(file_path, category_names, ignore_first_column,values_type="int"):
+def read_and_aggregate_csv(file_path, category_names, ignore_first_column=False, values_type="int"):
     df = pd.read_csv(file_path)
     # Deleting the first column of the csv if -I has been called
     if ignore_first_column == True:


### PR DESCRIPTION
This new option cuts the first column from the csv data. resto-googleforms.csv has the same data as resto.csv but needs to have its first column deleted before being processed. the command for the cutting column option is -I or ignore-first-column